### PR TITLE
Removing covariant in the == override

### DIFF
--- a/lib/src/firebase_image_provider.dart
+++ b/lib/src/firebase_image_provider.dart
@@ -142,10 +142,11 @@ class FirebaseImageProvider extends ImageProvider<FirebaseImageProvider> {
   }
 
   @override
-  bool operator ==(covariant FirebaseImageProvider other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other.options == options &&
+    return other is FirebaseImageProvider &&
+        other.options == options &&
         other.maxSize == maxSize &&
         other.scale == scale &&
         other.firebaseUrl == firebaseUrl;


### PR DESCRIPTION
Using covariant in this way disallows us to switch between image providers. This is because DecorationImage and the like use an equals check on their image provider.

As shown in error below, which was thrown when switching between an asset image and the firebase image: 

======== Exception caught by widgets library ======================================================= The following _TypeError was thrown building Builder(dirty, dependencies: [Directionality, MediaQuery, _LocalizationsScope-[GlobalKey#61773]]): type 'AssetImage' is not a subtype of type 'FirebaseImageProvider' of 'other'

The relevant error-causing widget was: 
  Ink Ink:file:///anon/lib/components/widget.dart:100:28
When the exception was thrown, this was the stack: 
0      FirebaseImageProvider.== (package:firebase_cached_image/src/firebase_image_provider.dart)
1      DecorationImage.== (package:flutter/src/painting/decoration_image.dart:196:24)
2      BoxDecoration.== (package:flutter/src/painting/box_decoration.dart:329:24)
3      InkDecoration.decoration= (package:flutter/src/material/ink_decoration.dart:355:15)
4      _InkState._build (package:flutter/src/material/ink_decoration.dart:292:13)
5      Builder.build (package:flutter/src/widgets/basic.dart:7448:48)
6      StatelessElement.build (package:flutter/src/widgets/framework.dart:5038:49)
7      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4968:15)